### PR TITLE
72 fix numpy warnings about scalars

### DIFF
--- a/sksurgerycore/transforms/matrix.py
+++ b/sksurgerycore/transforms/matrix.py
@@ -134,7 +134,8 @@ def construct_rotm_from_euler(
 
 
 def construct_rigid_transformation(rot_m, trans_v):
-    """Construct a 4x4 rigid-body transformation from a 3x3 rotation matrix and
+    """
+    Construct a 4x4 rigid-body transformation from a 3x3 rotation matrix and
     a 3x1 vector as translation
 
     :param rot_m: 3x3 rotation matrix, numpy array
@@ -148,8 +149,14 @@ def construct_rigid_transformation(rot_m, trans_v):
         for j in range(3):
             rigid_transformation[i][j] = rot_m[i][j]
 
-    rigid_transformation[0][3] = trans_v[0]
-    rigid_transformation[1][3] = trans_v[1]
-    rigid_transformation[2][3] = trans_v[2]
+    # While the specification is [3x1] which implies ndarray, the users
+    # may also pass in array (3,), ndarray (3, 1) or ndarray (1, 3).
+    # So, this will flatten all of them to the same array-like shape.
+    # In keeping with the rotation matrix, no range checking.
+    t_v = np.ravel(trans_v)
+
+    rigid_transformation[0][3] = t_v[0]
+    rigid_transformation[1][3] = t_v[1]
+    rigid_transformation[2][3] = t_v[2]
 
     return rigid_transformation

--- a/tox.ini
+++ b/tox.ini
@@ -1,40 +1,23 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py37,lint
+envlist = test,lint
 skipsdist = True
-requires = setuptools >= 47.1
-
-[travis]
-python =
-  3.7: py37, docs, lint
 
 [testenv]
-passenvs=GITHUB_*
+basepython=python3.10
+passenv = *
 deps=-rrequirements-dev.txt
+
+[testenv:test]
 whitelist_externals=coverage,pip
 # See .coveragerc for list of omitted files
 commands = coverage erase
-           coverage run -a --source ./sksurgerycore -m pytest
+           coverage run -a --source ./sksurgerycore -m pytest -v -s ./tests/
            coverage report -m
 
 [testenv:lint]
-basepython=python3.7
-deps=pylint
-     {[testenv]deps}
-commands=pylint --rcfile=tests/pylintrc sksurgerycore tests
+commands=pylint --rcfile=tests/pylintrc --ignore _version.py sksurgerycore tests
 
 [testenv:docs]
-basepython=python3.7
 changedir = docs
 commands = sphinx-build -M html . build
-
-[testenv:installer]
-basepython=python3.7
-commands=pyinstaller --onefile sksurgerycore.py --noconfirm --windowed
-
-[testenv:pip3]
-basepython=python3.7
-changedir=pip_test
-skip_install=True
-commands = pip install {posargs}
-           sksurgerycore --help


### PR DESCRIPTION
Minor tweak to remove deprecation warnings.
And tidy up tox.ini, to put code into a .tox/test folder and reduce the number of edits required when python version changes.